### PR TITLE
Gltd 125 flow field pathfinding

### DIFF
--- a/Gaian Labyrinth Tower Defense/Assets/Code/Scripts/BulletBehavior.cs
+++ b/Gaian Labyrinth Tower Defense/Assets/Code/Scripts/BulletBehavior.cs
@@ -11,7 +11,7 @@ public class BulletBehavior : MonoBehaviour
     public virtual void Start()
     {
         speed = 50f;
-        damage = 5f;
+        damage = 1f;
     }
 
     public virtual void Update()

--- a/Gaian Labyrinth Tower Defense/Assets/Code/Scripts/BulletBehavior.cs
+++ b/Gaian Labyrinth Tower Defense/Assets/Code/Scripts/BulletBehavior.cs
@@ -21,7 +21,7 @@ public class BulletBehavior : MonoBehaviour
 
     void OnTriggerEnter(Collider other)
     {
-        if(other.gameObject.tag == "Enemy")
+        if (other.gameObject.tag == "Enemy")
         {
             HitTarget(other.gameObject);
         }

--- a/Gaian Labyrinth Tower Defense/Assets/Code/Scripts/EnemyBehavior.cs
+++ b/Gaian Labyrinth Tower Defense/Assets/Code/Scripts/EnemyBehavior.cs
@@ -70,56 +70,37 @@ public class EnemyBehavior : MonoBehaviour
 
     private void moveAlongPath()
     {
-        //direction = normalize((goalPos + myHeightOffset) - currPos ); 
-        //myHeightOffset = my height but rotated to the normal of the goal. Need to set that up. Matrix/vector multiplication
-
-        Vector3 moveDirNormal = Vector3.Normalize((path[0].transform.position + new Vector3(0f, .5f, 0f)) - transform.position);
-
-        //should also rotate toward where you're moving
-
-        //movement = direction * speed;
-        //Debug.Log(moveDirNormal);
-        transform.position += moveDirNormal * moveSpeed * Time.deltaTime;
-
-        //if reach next tile in path, remove it from path.
-        if (Vector3.Distance(transform.position, path[0].gameObject.transform.position) < .8f)
-        {
-            //Debug.Log($"removing path[0]: {path[0].Coords}");
-            path.RemoveAt(0);
-        }
-    }
-
-    //called by tower placed event in Player. recalculates the A* path using the current tile the enemy is on and the goal tile.
-    private void recalculatePath(GridTile changedTile) //parameter from TowerPlaced event. unused for now
-    {
+        //get current tile. Might adjust this to check less often than on every frame.
         Ray ray = new Ray(this.transform.position, -this.transform.up);
-
         if (Physics.Raycast(ray, out RaycastHit hit, 10f, Grid))
         {
-            Debug.DrawRay(transform.position, transform.TransformDirection(Vector3.forward) * hit.distance, Color.yellow);
+            Debug.Log("hitting tile");
             currTile = hit.transform.GetComponent<GridTile>();
         }
-        path = pathFinder.FindPath(currTile, endTile);
-        if (path == null) // if no path to end, just go straight to it, for now.
-        {
-            path.Add(endTile.GetComponent<GridTile>());
-        }
+
+        //direction = normalize((successorPos + myHeightOffset) - currPos ); 
+        //myHeightOffset = my height but rotated to the normal of the goal. Need to set that up. Matrix/vector multiplication
+        Vector3 posToMoveToward = currTile.successor.transform.position;
+        Vector3 moveDirNormal = Vector3.Normalize((posToMoveToward + new Vector3(0f, .5f, 0f)) - transform.position);
+
+        transform.Translate(moveDirNormal * moveSpeed * Time.deltaTime);
+
+        //should also rotate toward where you're moving
     }
+
 
     void OnCollisionEnter(Collision collision)
     {
-        //get hit by some projectile
-            //lose health
-        //if currentHealth <= 0, Destroy(this)
+
     }
 
     private void OnEnable()
     {
-        Player.OnTowerPlaced += recalculatePath;
+        //Player.OnTowerPlaced += recalculatePath;
     }
     private void OnDisable()
     {
-        Player.OnTowerPlaced -= recalculatePath;
+        //Player.OnTowerPlaced -= recalculatePath;
     }
 
 }

--- a/Gaian Labyrinth Tower Defense/Assets/Code/Scripts/FlowFieldGenerator.cs
+++ b/Gaian Labyrinth Tower Defense/Assets/Code/Scripts/FlowFieldGenerator.cs
@@ -1,0 +1,56 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+
+public class FlowFieldGenerator
+{
+    //Calculate distance from goal of each tile, as well as setting their predecessor and successor tiles, starting from the goal tile itself.
+    //initDist is 0 when we are doing an initial calculation from the goal, and a different int if we are recalculating somewhere else in the map
+    public void GenerateField(GridTile goal, int initDist)
+    {
+        List<GridTile> frontierQueue = new List<GridTile>();
+        //list of calculated tiles, sorted by their distance from the goal.
+        List<GridTile> sortedTileList = new List<GridTile>();
+
+        goal.goalDist = initDist;
+        frontierQueue.Add(goal);
+
+        int count = 0;
+
+        while (frontierQueue.Count > 0 && count < 990)
+        {
+            count++;
+            Debug.Log(count);
+            //GridTile currentTile = frontierQueue.OrderBy(x => x.F).First();    
+            //if we end up giving tiles certain effects, like speed up and slow down, etc. (tower aoe slows won't count for pathing purposes)
+
+            GridTile currentTile = frontierQueue[0];
+            frontierQueue.RemoveAt(0);
+
+            sortedTileList.Add(currentTile);
+
+            //update dist values, push frontier queue along
+            foreach (GridTile adjTile in currentTile.adjacentTiles)
+            {
+                
+                if (adjTile.walkable && adjTile.goalDist > currentTile.goalDist) //walkable and not yet calculated (or needs to be recalculated)
+                {
+                    Debug.Log(currentTile);
+                    //setting distance from goal of adjTile based on current tile's distance. Assuming distance between each tile is 1 for now.
+                    adjTile.goalDist = currentTile.goalDist + 1;
+
+                    //current tile becomes a successor of the adjacent tile
+                    adjTile.successor = currentTile;
+
+                    //adjacent tile becomes a predecessor of this tile
+                    currentTile.predecessorList.Add(adjTile);
+
+                    //setting up adjacent tile to be calculated soon
+                    frontierQueue.Add(adjTile);
+                }
+            }
+        }
+    }
+
+}

--- a/Gaian Labyrinth Tower Defense/Assets/Code/Scripts/FlowFieldGenerator.cs
+++ b/Gaian Labyrinth Tower Defense/Assets/Code/Scripts/FlowFieldGenerator.cs
@@ -5,6 +5,8 @@ using UnityEngine;
 
 public class FlowFieldGenerator
 {
+    private List<GridTile> prevBottlenecks = new List<GridTile>();
+
     //Calculate distance from goal of each tile, as well as setting their predecessor and successor tiles, starting from the goal tile itself.
     //initDist is 0 when we are doing an initial calculation from the goal, and a different int if we are recalculating somewhere else in the map
     public void GenerateField(GridTile goal, int initDist)
@@ -18,39 +20,110 @@ public class FlowFieldGenerator
 
         int count = 0;
 
-        while (frontierQueue.Count > 0 && count < 990)
+        while (frontierQueue.Count > 0 && count < 1100)
         {
             count++;
-            Debug.Log(count);
+            //Debug.Log(count);
             //GridTile currentTile = frontierQueue.OrderBy(x => x.F).First();    
             //if we end up giving tiles certain effects, like speed up and slow down, etc. (tower aoe slows won't count for pathing purposes)
+
+            //Debug.Log($"Frontier Queue start of loop:\n {printQueue(frontierQueue)}");
 
             GridTile currentTile = frontierQueue[0];
             frontierQueue.RemoveAt(0);
 
             sortedTileList.Add(currentTile);
+            currentTile.predecessorList.Clear();
 
             //update dist values, push frontier queue along
             foreach (GridTile adjTile in currentTile.adjacentTiles)
             {
-                
-                if (adjTile.walkable && adjTile.goalDist > currentTile.goalDist) //walkable and not yet calculated (or needs to be recalculated)
+                if (adjTile.walkable && adjTile.goalDist > currentTile.goalDist && !adjTile.fielded) //walkable and not yet calculated (or needs to be recalculated)
                 {
-                    Debug.Log(currentTile);
-                    //setting distance from goal of adjTile based on current tile's distance. Assuming distance between each tile is 1 for now.
-                    adjTile.goalDist = currentTile.goalDist + 1;
-
                     //current tile becomes a successor of the adjacent tile
                     adjTile.successor = currentTile;
+                    
+                    /*
+                    //current tile becomes a successor of the adjacent tile
+                    if (initDist == 0)
+                        adjTile.successor = currentTile;
+                    //or set up a function to take the minimum of all 4 adjacents as its successor?
+                    else if (initDist > 0)
+                    {
+                        Debug.Log("recalcing successor");
+                        adjTile.successor = adjTile.recalcSuccessor();
+                    }
+                    */
+
+                    //setting distance from goal of adjTile based on current tile's distance. Assuming distance between each tile is 1 for now.
+                    adjTile.goalDist = adjTile.successor.goalDist + 1;
 
                     //adjacent tile becomes a predecessor of this tile
                     currentTile.predecessorList.Add(adjTile);
 
                     //setting up adjacent tile to be calculated soon
                     frontierQueue.Add(adjTile);
+                    adjTile.fielded = true;
+                }
+                else
+                {
+                    //Debug.Log($"didn't add adj tile: {adjTile}");
                 }
             }
         }
+        foreach (GridTile t in sortedTileList)
+        {
+            t.fielded = false;
+        }
+        Debug.Log($"Sorted tile list length: {sortedTileList.Count}");
+        Debug.Log($"end queue: {printQueue(frontierQueue)}");
+        determineBottlenecks(sortedTileList);
+    }
+
+    //Adjustment
+    //check if it's the only tile of that distance with a predecessor
+    //can have others at that distance if they don't have predecessors
+    //if predecessorCount > 0 and all others at that distance have preecessorCount = 0, then you're a bottleneck
+
+    //determine all tiles where placing a tower on them would cut off all possible paths for enemies.
+    private void determineBottlenecks(List<GridTile> sortedTileList)
+    {
+        //reset bottlenecks from previous flow field calculation
+        foreach (GridTile b in prevBottlenecks)
+        {
+            b.placeable = true;
+            prevBottlenecks.Remove(b);
+        }
+
+        int i = 0;
+        while (sortedTileList[i].goalDist == 0 && i < sortedTileList.Count)
+            i++;
+        if (i == sortedTileList.Count)
+            Debug.Log("Something went very wrong in determining bottlenecks");
+        for (int j = i; j < sortedTileList.Count - 1; j++)
+        {
+            //if the tile is placeable, and there are no other tiles of this distance, and this tile has a predecessor, this tile is a bottleneck.
+            if (sortedTileList[j].placeable && sortedTileList[j].goalDist > sortedTileList[j - 1].goalDist && 
+                sortedTileList[j].goalDist < sortedTileList[j+1].goalDist && 
+                sortedTileList[j].predecessorList.Count > 0)
+            {
+                prevBottlenecks.Add(sortedTileList[j]);
+                sortedTileList[j].placeable = false;
+            }
+        }
+
+        Debug.Log($"Bottlenecks: {printQueue(prevBottlenecks)}");
+    }
+
+
+    private string printQueue(List<GridTile> queue)
+    {
+        string queueStr = string.Empty;
+        foreach (GridTile a in queue)
+        {
+            queueStr += a + " ";
+        }
+        return queueStr;
     }
 
 }

--- a/Gaian Labyrinth Tower Defense/Assets/Code/Scripts/FlowFieldGenerator.cs.meta
+++ b/Gaian Labyrinth Tower Defense/Assets/Code/Scripts/FlowFieldGenerator.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: e6ce152f891b92a43bc187c35261ed21
+guid: 7e09830efb7ac37449223f5d1d9789b3
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Gaian Labyrinth Tower Defense/Assets/Code/Scripts/GoalTile.cs
+++ b/Gaian Labyrinth Tower Defense/Assets/Code/Scripts/GoalTile.cs
@@ -6,6 +6,12 @@ public class GoalTile : GridTile
 {
     //might have event here for when an enemy reaches this kind of tile.
 
+    void Start()
+    {
+        goalDist = 0;
+        placeable = false;
+    }
+
     void OnDrawGizmos()
     {
         // Draw a semitransparent blue box at the transforms position

--- a/Gaian Labyrinth Tower Defense/Assets/Code/Scripts/GridTile.cs
+++ b/Gaian Labyrinth Tower Defense/Assets/Code/Scripts/GridTile.cs
@@ -21,6 +21,7 @@ public class GridTile : MonoBehaviour
 
     public GridTile successor;
     public List<GridTile> predecessorList;
+    public bool fielded;
 
 
     //A* algorithm things. G is distance from start, H is distance from end, F is the total of both.
@@ -33,12 +34,13 @@ public class GridTile : MonoBehaviour
 
     public bool walkable = true; //whether an enemy can path through it. False when tower on it or due to unique environment.
     public bool placeable = true; //whether a tower can be placed on it. False while enemies on it or due to unique environment.
-
-
+    public bool enemyOnTile = false;
+    public bool towerOnTile = false;
 
     void Awake()
     {
         goalDist = 999;
+        fielded = false;
         Coords = setCoords();
         adjacentTiles = new List<GridTile>();
         setAdjTiles();
@@ -53,7 +55,7 @@ public class GridTile : MonoBehaviour
     // Update is called once per frame
     void Update()
     {
-        
+        enemyOnTile = false;
     }
 
     void OnDrawGizmos()
@@ -90,6 +92,19 @@ public class GridTile : MonoBehaviour
             if (col.gameObject != gameObject) 
                 adjacentTiles.Add(col.gameObject.GetComponent<GridTile>());
         }
+    }
+
+    public GridTile recalcSuccessor()
+    {
+        GridTile newSuccessor = successor;
+        
+        foreach (GridTile adjTile in adjacentTiles)
+            if (adjTile.walkable && adjTile.goalDist < newSuccessor.goalDist)
+                newSuccessor = adjTile;
+        //if nothing changed and the successor was unwalkable
+        if (!successor.walkable && newSuccessor == successor)
+            newSuccessor = null;
+        return newSuccessor;
     }
 
     //displays the tile's coords and adjacent tile coords

--- a/Gaian Labyrinth Tower Defense/Assets/Code/Scripts/GridTile.cs
+++ b/Gaian Labyrinth Tower Defense/Assets/Code/Scripts/GridTile.cs
@@ -5,8 +5,6 @@ using UnityEngine;
 
 public class GridTile : MonoBehaviour
 {
-    //Might make a dictionary of all tiles, and use the coords var as key.
-        //then can get the spawn tile and goal tile from the dictionary?
 
     //coords = unique identifier among all grid tiles. public get, private set.
     private (int x, int y, int z) coords;
@@ -15,21 +13,32 @@ public class GridTile : MonoBehaviour
         private set { coords = value; }
     }
 
+    //distance from goal
+    public int goalDist;
+
+    //list of adjacent grid tiles, for calculating the path.
+    public List<GridTile> adjacentTiles { get; private set; }
+
+    public GridTile successor;
+    public List<GridTile> predecessorList;
+
+
     //A* algorithm things. G is distance from start, H is distance from end, F is the total of both.
     //distance isn't actual distance, but Manhattan distance (so cardinal directions only)
     public int G;
     public int H;
-    public int F { get {return G + H; } }
+    public int F { get { return G + H; } }
     public GridTile previous;
 
-    //list of adjacent grid tiles, for calculating the path.
-    public List<GridTile> adjacentTiles { get; private set; } 
 
     public bool walkable = true; //whether an enemy can path through it. False when tower on it or due to unique environment.
     public bool placeable = true; //whether a tower can be placed on it. False while enemies on it or due to unique environment.
 
+
+
     void Awake()
     {
+        goalDist = 999;
         Coords = setCoords();
         adjacentTiles = new List<GridTile>();
         setAdjTiles();

--- a/Gaian Labyrinth Tower Defense/Assets/Code/Scripts/LevelManager.cs
+++ b/Gaian Labyrinth Tower Defense/Assets/Code/Scripts/LevelManager.cs
@@ -16,6 +16,9 @@ public class LevelManager : MonoBehaviour
 
     public int currWave = 0;
 
+    [SerializeField] private GameObject goalTile;
+    public FlowFieldGenerator flowFieldGenerator;
+
 
     //[SerializeField]
     public int remainingLives = 20;
@@ -29,6 +32,8 @@ public class LevelManager : MonoBehaviour
     // Start is called before the first frame update
     void Start()
     {
+        flowFieldGenerator = new FlowFieldGenerator();
+        flowFieldGenerator.GenerateField(goalTile.GetComponent<GridTile>(), 0);
         waveCountdown = 1f;
         remainingLives += 5;
     }

--- a/Gaian Labyrinth Tower Defense/Assets/Code/Scripts/Player.cs
+++ b/Gaian Labyrinth Tower Defense/Assets/Code/Scripts/Player.cs
@@ -7,6 +7,9 @@ public class Player : MonoBehaviour
     public delegate void TowerPlaced(GridTile tileOn);
     public static event TowerPlaced OnTowerPlaced;
 
+    public delegate void TowerSold(GridTile tileOn);
+    public static event TowerSold OnTowerSold;
+
     public playerMode currentMode;
 
     //Variables to control and determine player's jumping abiltiy
@@ -241,7 +244,7 @@ public class Player : MonoBehaviour
             {
                 GridTile currTileScript = hit.transform.GetComponent<GridTile>();
 
-                if (currTileScript.placeable)
+                if (currTileScript.placeable && !currTileScript.enemyOnTile)
                 {
                     //displaying the potential placement spot for the tower
                     tempDisplayHolder = Instantiate(towerDisplayPrefab, new Vector3(hit.transform.position.x, transform.position.y, hit.transform.position.z), transform.rotation);
@@ -257,6 +260,7 @@ public class Player : MonoBehaviour
 
                             currTileScript.placeable = false;
                             currTileScript.walkable = false;
+                            currTileScript.towerOnTile = true;
 
                             Debug.Log($"Currency before tower placement: {currency}");
                             currency -= tower.cost;
@@ -272,9 +276,23 @@ public class Player : MonoBehaviour
 
                     }
                 }
+                else if (!currTileScript.towerOnTile)
+                {
+                    //displaying the potential placement spot for the tower, red when disallowed
+                    tempDisplayHolder = Instantiate(towerDisplayPrefab, new Vector3(hit.transform.position.x, transform.position.y, hit.transform.position.z), transform.rotation);
+                    // Call SetColor using the shader property name "_Color" and setting the color to red
+                    tempDisplayHolder.transform.Find("Body").GetComponent<Renderer>().material.SetColor("_Color", new Color(.9f, .1f, .1f, .2f));
+                }
             }   
         }
         
+    }
+
+    private void sellTower()
+    {
+        GridTile tileOn = null;
+        //invoke this event with the tile the tower was on.
+        OnTowerSold?.Invoke(tileOn);
     }
 
     private void GainCurrency(GameObject enemyWhoDied)

--- a/Gaian Labyrinth Tower Defense/Assets/Code/Scripts/SpawnPoint.cs
+++ b/Gaian Labyrinth Tower Defense/Assets/Code/Scripts/SpawnPoint.cs
@@ -57,7 +57,7 @@ public class SpawnPoint : GridTile
             GameObject currEnemy = Instantiate(waveSet[waveNum - 1].waveEnemies[i], transform.position, transform.rotation);
             EnemyBehavior currEnemyScript = currEnemy.GetComponent<EnemyBehavior>();
             currEnemyScript.path = new List<GridTile>(path);
-            currEnemyScript.currTile = path[0];
+            currEnemyScript.currTile = this.GetComponent<GridTile>();
             currEnemyScript.endTile = endTile.GetComponent<GridTile>();
             //Debug.Log($"enemy {i} pos: {currEnemy.transform.position}");
 

--- a/Gaian Labyrinth Tower Defense/Assets/Code/Scripts/SpawnPoint.cs
+++ b/Gaian Labyrinth Tower Defense/Assets/Code/Scripts/SpawnPoint.cs
@@ -10,9 +10,6 @@ public class SpawnPoint : GridTile
     //2D array [wave number, enemies to spawn in that wave]
     public WaveStruct[] waveSet;
 
-    //Path for enemies that spawn here.
-    private PathFinder pathFinder;
-    public List<GridTile> path;
 
     //goal of the path. manually put it into inspector for now. (select the instance on scene, and drag the instance in scene of the goal tile to this instance's inspector)
     [SerializeField]
@@ -22,25 +19,8 @@ public class SpawnPoint : GridTile
     // Start is called before the first frame update
     void Start()
     {
-        pathFinder = new PathFinder();
-
-        //at start of each wave, re-calculate path (later make it so it recalculates on tower placement on path, or any towers being sold)
-        //might want a list or dictionary of every tile, then can grab any with "endpoint" flag or w/e, and pick the closest one for this next line
-        //takes scripts of start tile and end tile.
-        calculatePath(this);
-
-        printPath();
+        placeable = false;
     }
-
-    private void calculatePath(GridTile changedTile) //parameter comes from the event invoking it (on tower placement). unused here for now
-    {
-        path = pathFinder.FindPath(this, endTile.GetComponent<GridTile>());
-        if (path == null) // if no path to end, just go straight to it, for now.
-        {
-            path.Add(endTile.GetComponent<GridTile>());
-        }
-    }
-
 
     //invoked by OnWaveStart event from LevelManager
     //instantiates enemies based on the current wave and the listed enemies (added in inspector) for that wave.
@@ -56,12 +36,8 @@ public class SpawnPoint : GridTile
         {
             GameObject currEnemy = Instantiate(waveSet[waveNum - 1].waveEnemies[i], transform.position, transform.rotation);
             EnemyBehavior currEnemyScript = currEnemy.GetComponent<EnemyBehavior>();
-            currEnemyScript.path = new List<GridTile>(path);
             currEnemyScript.currTile = this.GetComponent<GridTile>();
-            currEnemyScript.endTile = endTile.GetComponent<GridTile>();
-            //Debug.Log($"enemy {i} pos: {currEnemy.transform.position}");
 
-            //Debug.Log($"stalling in spawnDelay for {timeToWait} sec");
             yield return new WaitForSeconds(timeToWait);
         }
     }
@@ -78,25 +54,12 @@ public class SpawnPoint : GridTile
     private void OnEnable()
     {
         LevelManager.OnWaveStart += WaveStart;
-        Player.OnTowerPlaced += calculatePath;
     }
     private void OnDisable()
     {
         LevelManager.OnWaveStart -= WaveStart;
-        Player.OnTowerPlaced -= calculatePath;
     }
 
-    //checking path in console.
-    private void printPath()
-    {
-        string pathString = "";
-        foreach (GridTile s in path)
-        {
-            //Debug.Log("pathElement: " + s);
-            pathString += " " + s.Coords;
-        }
-        Debug.Log($"Path from spawn point {spawnPointNumber}: {pathString}");
-    }
 }
 
 [System.Serializable]

--- a/Gaian Labyrinth Tower Defense/Assets/Code/Scripts/TowerBehavior.cs
+++ b/Gaian Labyrinth Tower Defense/Assets/Code/Scripts/TowerBehavior.cs
@@ -4,8 +4,6 @@ using UnityEngine;
 
 public class TowerBehavior : MonoBehaviour
 {
-    public delegate void TargetingError(GameObject gameObj);
-    public static event TargetingError OnTargetingError;
 
     public GameObject target;
 
@@ -138,7 +136,9 @@ public class TowerBehavior : MonoBehaviour
         catch
         {
             Debug.Log("Tower trying to target in empty enemy list. Would have sent a MissingReferenceException regarding the foreach (GameObject enemy in enemies)");
-            OnTargetingError?.Invoke(gameObject);
+            detectionZone.enabled = false;
+            enemies.Clear();
+            detectionZone.enabled = true;
         }
     }
 

--- a/Gaian Labyrinth Tower Defense/Assets/Code/Scripts/UIManager.cs
+++ b/Gaian Labyrinth Tower Defense/Assets/Code/Scripts/UIManager.cs
@@ -9,8 +9,11 @@ public class UIManager : MonoBehaviour
     public TMP_Text WavesText; 
     public TMP_Text TimeText;
     public TMP_Text LivesText;
+    public TMP_Text CurrencyText;
     [SerializeField]
     private GameObject levelManager;
+    [SerializeField]
+    private GameObject player;
 
     //private int counter = 0;
 
@@ -25,6 +28,7 @@ public class UIManager : MonoBehaviour
         WavesText.text = "Wave: " + levelManager.GetComponent<LevelManager>().currWave.ToString();
         TimeText.text = "Time to next wave: " + ((int)levelManager.GetComponent<LevelManager>().waveCountdown).ToString();
         LivesText.text = "Lives: " + levelManager.GetComponent<LevelManager>().remainingLives.ToString();
+        CurrencyText.text = "$" + player.GetComponent<Player>().currency.ToString();
         //LivesText.text = "hey " + counter;
         //counter++;
     }

--- a/Gaian Labyrinth Tower Defense/Assets/Level/Prefabs/BulletPrefab.prefab
+++ b/Gaian Labyrinth Tower Defense/Assets/Level/Prefabs/BulletPrefab.prefab
@@ -143,7 +143,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 5460506940467439282}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 472f0708a565e294a9e72c6056badbd8, type: 3}
+  m_Script: {fileID: 11500000, guid: e6ce152f891b92a43bc187c35261ed21, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   speed: 0

--- a/Gaian Labyrinth Tower Defense/Assets/Level/Prefabs/GridTilePrefab.prefab
+++ b/Gaian Labyrinth Tower Defense/Assets/Level/Prefabs/GridTilePrefab.prefab
@@ -66,5 +66,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 84b4dea737211934c867b05e640ab94a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  goalDist: 0
+  successor: {fileID: 0}
+  predecessorList: []
+  fielded: 0
+  G: 0
+  H: 0
+  previous: {fileID: 0}
   walkable: 1
   placeable: 1

--- a/Gaian Labyrinth Tower Defense/Assets/Level/Prefabs/TowerDisplayPlaceholder.prefab
+++ b/Gaian Labyrinth Tower Defense/Assets/Level/Prefabs/TowerDisplayPlaceholder.prefab
@@ -44,7 +44,7 @@ GameObject:
   - component: {fileID: 4754190570738438907}
   - component: {fileID: 4383115609391359146}
   m_Layer: 0
-  m_Name: Cylinder
+  m_Name: Body
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0

--- a/Gaian Labyrinth Tower Defense/Assets/Level/Prefabs/TrackingBulletPrefab.prefab
+++ b/Gaian Labyrinth Tower Defense/Assets/Level/Prefabs/TrackingBulletPrefab.prefab
@@ -99,7 +99,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   speed: 50
-  damage: 2
+  damage: 1
 --- !u!135 &5920508708287658196
 SphereCollider:
   m_ObjectHideFlags: 0

--- a/Gaian Labyrinth Tower Defense/Assets/Scenes/TestScene1.unity
+++ b/Gaian Labyrinth Tower Defense/Assets/Scenes/TestScene1.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.44657874, g: 0.49641275, b: 0.5748171, a: 1}
+  m_IndirectSpecularColor: {r: 0.44657826, g: 0.49641263, b: 0.57481676, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -56859,6 +56859,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   waveCountdown: 0
   currWave: 0
+  goalTile: {fileID: 1443872102}
   remainingLives: 20
 --- !u!4 &1748067189
 Transform:

--- a/Gaian Labyrinth Tower Defense/Assets/Scenes/TestScene1.unity
+++ b/Gaian Labyrinth Tower Defense/Assets/Scenes/TestScene1.unity
@@ -2327,6 +2327,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: GridTilePrefab (13)
       objectReference: {fileID: 0}
+    - target: {fileID: 5712104861848025719, guid: 73ec4d64252f0034c8d7d3f10813a186, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 6542469190092354620, guid: 73ec4d64252f0034c8d7d3f10813a186, type: 3}
       propertyPath: m_Size.y
       value: 0.2
@@ -8084,6 +8088,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: GridTilePrefab (16)
       objectReference: {fileID: 0}
+    - target: {fileID: 5712104861848025719, guid: 73ec4d64252f0034c8d7d3f10813a186, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 6542469190092354620, guid: 73ec4d64252f0034c8d7d3f10813a186, type: 3}
       propertyPath: m_Size.y
       value: 0.2
@@ -9850,6 +9858,7 @@ RectTransform:
   - {fileID: 1387215726}
   - {fileID: 1407666037}
   - {fileID: 2102790346}
+  - {fileID: 789391893}
   m_Father: {fileID: 1526572918}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -11416,6 +11425,10 @@ PrefabInstance:
     - target: {fileID: 5712104861848025719, guid: 73ec4d64252f0034c8d7d3f10813a186, type: 3}
       propertyPath: m_Name
       value: GridTilePrefab (15)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5712104861848025719, guid: 73ec4d64252f0034c8d7d3f10813a186, type: 3}
+      propertyPath: m_IsActive
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6542469190092354620, guid: 73ec4d64252f0034c8d7d3f10813a186, type: 3}
       propertyPath: m_Size.y
@@ -19853,6 +19866,140 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 7171033322945162878, guid: 73ec4d64252f0034c8d7d3f10813a186, type: 3}
   m_PrefabInstance: {fileID: 2047274569}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &596479697
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 596479700}
+  - component: {fileID: 596479699}
+  - component: {fileID: 596479698}
+  m_Layer: 5
+  m_Name: CurrencyText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &596479698
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 596479697}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: 'Currency:'
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 1
+  m_colorMode: 2
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 0, b: 0, a: 1}
+    topRight: {r: 1, g: 0, b: 0, a: 1}
+    bottomLeft: {r: 1, g: 0.687739, b: 0, a: 1}
+    bottomRight: {r: 1, g: 0.687739, b: 0, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 36
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &596479699
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 596479697}
+  m_CullTransparentMesh: 1
+--- !u!224 &596479700
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 596479697}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 789391893}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 200, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1001 &596900351
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -20160,6 +20307,10 @@ PrefabInstance:
     - target: {fileID: 5712104861848025719, guid: 73ec4d64252f0034c8d7d3f10813a186, type: 3}
       propertyPath: m_Name
       value: GridTilePrefab (17)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5712104861848025719, guid: 73ec4d64252f0034c8d7d3f10813a186, type: 3}
+      propertyPath: m_IsActive
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6542469190092354620, guid: 73ec4d64252f0034c8d7d3f10813a186, type: 3}
       propertyPath: m_Size.y
@@ -21525,6 +21676,10 @@ PrefabInstance:
     - target: {fileID: 5712104861848025719, guid: 73ec4d64252f0034c8d7d3f10813a186, type: 3}
       propertyPath: m_Name
       value: GridTilePrefab (12)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5712104861848025719, guid: 73ec4d64252f0034c8d7d3f10813a186, type: 3}
+      propertyPath: m_IsActive
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6542469190092354620, guid: 73ec4d64252f0034c8d7d3f10813a186, type: 3}
       propertyPath: m_Size.y
@@ -25563,6 +25718,82 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 7171033322945162878, guid: 73ec4d64252f0034c8d7d3f10813a186, type: 3}
   m_PrefabInstance: {fileID: 639225103}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &789391892
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 789391893}
+  - component: {fileID: 789391895}
+  - component: {fileID: 789391894}
+  m_Layer: 5
+  m_Name: Currency
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &789391893
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 789391892}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 596479700}
+  m_Father: {fileID: 251208320}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.8488702}
+  m_AnchorMax: {x: 0.344, y: 1}
+  m_AnchoredPosition: {x: -0.0034179688, y: -2}
+  m_SizeDelta: {x: 0.22680664, y: 0.77001953}
+  m_Pivot: {x: 0, y: 1}
+--- !u!114 &789391894
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 789391892}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0, b: 0, a: 0.392}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &789391895
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 789391892}
+  m_CullTransparentMesh: 1
 --- !u!4 &792771787 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 7171033322945162878, guid: 73ec4d64252f0034c8d7d3f10813a186, type: 3}
@@ -26901,6 +27132,10 @@ PrefabInstance:
     - target: {fileID: 5712104861848025719, guid: 73ec4d64252f0034c8d7d3f10813a186, type: 3}
       propertyPath: m_Name
       value: GridTilePrefab (12)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5712104861848025719, guid: 73ec4d64252f0034c8d7d3f10813a186, type: 3}
+      propertyPath: m_IsActive
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6542469190092354620, guid: 73ec4d64252f0034c8d7d3f10813a186, type: 3}
       propertyPath: m_Size.y
@@ -35819,7 +36054,9 @@ MonoBehaviour:
   WavesText: {fileID: 412797267}
   TimeText: {fileID: 2133462929}
   LivesText: {fileID: 982388257}
+  CurrencyText: {fileID: 596479698}
   levelManager: {fileID: 1748067187}
+  player: {fileID: 1299577097}
 --- !u!4 &1143071468
 Transform:
   m_ObjectHideFlags: 0
@@ -36311,6 +36548,10 @@ PrefabInstance:
     - target: {fileID: 5712104861848025719, guid: 73ec4d64252f0034c8d7d3f10813a186, type: 3}
       propertyPath: m_Name
       value: GridTilePrefab (14)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5712104861848025719, guid: 73ec4d64252f0034c8d7d3f10813a186, type: 3}
+      propertyPath: m_IsActive
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6542469190092354620, guid: 73ec4d64252f0034c8d7d3f10813a186, type: 3}
       propertyPath: m_Size.y
@@ -37900,6 +38141,10 @@ PrefabInstance:
     - target: {fileID: 5712104861848025719, guid: 73ec4d64252f0034c8d7d3f10813a186, type: 3}
       propertyPath: m_Name
       value: GridTilePrefab (16)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5712104861848025719, guid: 73ec4d64252f0034c8d7d3f10813a186, type: 3}
+      propertyPath: m_IsActive
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6542469190092354620, guid: 73ec4d64252f0034c8d7d3f10813a186, type: 3}
       propertyPath: m_Size.y
@@ -42453,6 +42698,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: GridTilePrefab (14)
       objectReference: {fileID: 0}
+    - target: {fileID: 5712104861848025719, guid: 73ec4d64252f0034c8d7d3f10813a186, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 6542469190092354620, guid: 73ec4d64252f0034c8d7d3f10813a186, type: 3}
       propertyPath: m_Size.y
       value: 0.2
@@ -45264,6 +45513,10 @@ PrefabInstance:
     - target: {fileID: 5712104861848025719, guid: 73ec4d64252f0034c8d7d3f10813a186, type: 3}
       propertyPath: m_Name
       value: GridTilePrefab (15)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5712104861848025719, guid: 73ec4d64252f0034c8d7d3f10813a186, type: 3}
+      propertyPath: m_IsActive
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6542469190092354620, guid: 73ec4d64252f0034c8d7d3f10813a186, type: 3}
       propertyPath: m_Size.y
@@ -59475,6 +59728,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: GridTilePrefab (13)
       objectReference: {fileID: 0}
+    - target: {fileID: 5712104861848025719, guid: 73ec4d64252f0034c8d7d3f10813a186, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 6542469190092354620, guid: 73ec4d64252f0034c8d7d3f10813a186, type: 3}
       propertyPath: m_Size.y
       value: 0.2
@@ -60868,6 +61125,10 @@ PrefabInstance:
     - target: {fileID: 5712104861848025719, guid: 73ec4d64252f0034c8d7d3f10813a186, type: 3}
       propertyPath: m_Name
       value: GridTilePrefab (15)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5712104861848025719, guid: 73ec4d64252f0034c8d7d3f10813a186, type: 3}
+      propertyPath: m_IsActive
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6542469190092354620, guid: 73ec4d64252f0034c8d7d3f10813a186, type: 3}
       propertyPath: m_Size.y
@@ -62860,6 +63121,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: GridTilePrefab (14)
       objectReference: {fileID: 0}
+    - target: {fileID: 5712104861848025719, guid: 73ec4d64252f0034c8d7d3f10813a186, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 6542469190092354620, guid: 73ec4d64252f0034c8d7d3f10813a186, type: 3}
       propertyPath: m_Size.y
       value: 0.2
@@ -64815,6 +65080,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: GridTilePrefab (13)
       objectReference: {fileID: 0}
+    - target: {fileID: 5712104861848025719, guid: 73ec4d64252f0034c8d7d3f10813a186, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 6542469190092354620, guid: 73ec4d64252f0034c8d7d3f10813a186, type: 3}
       propertyPath: m_Size.y
       value: 0.2
@@ -65134,6 +65403,10 @@ PrefabInstance:
     - target: {fileID: 5712104861848025719, guid: 73ec4d64252f0034c8d7d3f10813a186, type: 3}
       propertyPath: m_Name
       value: GridTilePrefab (12)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5712104861848025719, guid: 73ec4d64252f0034c8d7d3f10813a186, type: 3}
+      propertyPath: m_IsActive
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6542469190092354620, guid: 73ec4d64252f0034c8d7d3f10813a186, type: 3}
       propertyPath: m_Size.y


### PR DESCRIPTION
Flow Field pathfinding mostly functional. Runs breadth-first search to generate distance from goal for each tile, as well as setting successor and predecessor tiles for each tile, to direct enemies along paths from any point on map. Only one calculation necessary for entire map, compared to A* calculating for every enemy (though recalculation of the flow field does happen with each tower placement; haven't gotten it working to do only a partial recalculation as of yet).

Updates entire field on tower placement

Prepared for tower selling to be implemented, though that might not work as is.

Tower placement not disabled at bottlenecks for the moment (when placing a tower in a spot would cut off all possible enemy paths to goal). Still working on that.

Added quick and dirty currency HUD panel

Patched tower bug by disabling and re-enabling their sphere collider to refresh the enemy list completely whenever the issue crops up.